### PR TITLE
Update ssh_into_kubelet.sh to use ctr tasks exec

### DIFF
--- a/projects/kubernetes/ssh_into_kubelet.sh
+++ b/projects/kubernetes/ssh_into_kubelet.sh
@@ -15,4 +15,4 @@ case $(uname -s) in
 	    ijc25/alpine-ssh"
 	;;
 esac
-$ssh $sshopts -t root@"$1" ctr exec --tty --exec-id ssh kubelet ash -l
+$ssh $sshopts -t root@"$1" ctr tasks exec --tty --exec-id ssh kubelet ash -l


### PR DESCRIPTION
PR #1299 moved "ctr exec" into "ctr tasks exec" so update the kubernetes project to reflect this.

Signed-off-by: Tim Potter <tpot@hpe.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix ssh_into_kubelet.sh script to work.

**- How I did it**

s/ctr exec/ctr tasks exec/

**- How to verify it**

Follow instructions in README.md in projects/kubernetes directory to create a cluster and verify running ./ssh_into_kubelet.sh actually runs ssh into the kubelet container.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Update ssh_into_kubelet.sh to use ctr tasks exec.

**- A picture of a cute animal (not mandatory but encouraged)**

```
                 _.-'\          |\-"""-/|          /`-._
             _.-`     `.       /         \       ,'     '-._
          _.'           `._   ;   \   /   ;   _,'           `._
        .'                 `-.:           :.-'                 `.
      ,`                           , ,                           '.
    ,`                                                             '.
   /                                                                 \
  :,-"""-,                                                     ,-"""-,:
 /'       `                                                   '       '\
          :                                                   :
          : ,-"""-,                                   ,-"""-, :
          /'       `.       _.-'         '-._       .'       '\
                     \    .`    :       :    '.    /
                      . .`       :     :       '. .
                      :/          :   :          \:
                      :            : :            :
                                    :
```